### PR TITLE
[23128 | DEV] Corrigindo comportamento ativo do item do menu lateral

### DIFF
--- a/src/components/UI/organism/sidebar/UI/molecules/building-block/use-building-block.hook.ts
+++ b/src/components/UI/organism/sidebar/UI/molecules/building-block/use-building-block.hook.ts
@@ -6,8 +6,12 @@ export const useBuildingBlockHook = () => {
 
   const navigateToLink = (path: string) => navigate.push(path);
 
-  const thisBuildingBlockIsActive = (buildingBlockPath: string) =>
-    buildingBlockPath === pathname;
+  const thisBuildingBlockIsActive = (buildingBlockPath: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, path] = pathname.split('/');
+
+    return buildingBlockPath === `/${path}`;
+  };
 
   return {
     navigateToLink,


### PR DESCRIPTION
Quando o usuário está numa tela tipo: '/coffee-shops/create/step-1', o item do menu lateral não fica com o comportamento ativo.